### PR TITLE
feat(phase-3): calorie dashboard with summaries, meal history, and log management

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -1,0 +1,40 @@
+import type { Config } from 'jest'
+
+/**
+ * Minimal Jest configuration that lets us run the project's TypeScript test
+ * files via ts-jest. We restrict discovery to the project's `src/` directory
+ * (and root-level `middleware.test.ts`) so unrelated nested worktrees do not
+ * collide with Jest's haste map.
+ */
+const config: Config = {
+  testEnvironment: 'node',
+  preset: 'ts-jest',
+  rootDir: '.',
+  // Limit roots to this checkout's `src/` so unrelated nested worktrees do
+  // not collide with Jest's haste map (multiple package.json with the same
+  // name).
+  roots: ['<rootDir>/src'],
+  testPathIgnorePatterns: ['/node_modules/', '/.next/'],
+  testMatch: ['<rootDir>/src/**/*.test.(ts|tsx)'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          jsx: 'react-jsx',
+          esModuleInterop: true,
+          module: 'commonjs',
+          moduleResolution: 'node',
+          target: 'ES2017',
+          types: ['jest', 'node'],
+        },
+        diagnostics: false,
+      },
+    ],
+  },
+}
+
+export default config

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,8 +3,7 @@ import type { Config } from 'jest'
 /**
  * Minimal Jest configuration that lets us run the project's TypeScript test
  * files via ts-jest. We restrict discovery to the project's `src/` directory
- * (and root-level `middleware.test.ts`) so unrelated nested worktrees do not
- * collide with Jest's haste map.
+ * so unrelated nested worktrees do not collide with Jest's haste map.
  */
 const config: Config = {
   testEnvironment: 'node',

--- a/src/app/api/nutrition-logs/[id]/route.ts
+++ b/src/app/api/nutrition-logs/[id]/route.ts
@@ -45,15 +45,28 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    let body: NutritionLogPatchBody
+    let parsedBody: unknown
     try {
-      body = await request.json()
+      parsedBody = await request.json()
     } catch {
       return NextResponse.json(
         { error: 'Invalid JSON in request body' },
         { status: 400 }
       )
     }
+
+    if (
+      !parsedBody ||
+      typeof parsedBody !== 'object' ||
+      Array.isArray(parsedBody)
+    ) {
+      return NextResponse.json(
+        { error: 'Request body must be an object' },
+        { status: 400 }
+      )
+    }
+
+    const body = parsedBody as NutritionLogPatchBody
 
     const updates: Record<string, unknown> = {}
 
@@ -109,7 +122,7 @@ export async function PATCH(request: NextRequest, context: RouteContext) {
       .eq('id', id)
       .eq('user_id', user.id)
       .select()
-      .single()
+      .maybeSingle()
 
     if (error) {
       console.error('Database error (PATCH nutrition log):', error)
@@ -152,22 +165,53 @@ export async function DELETE(_request: NextRequest, context: RouteContext) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
     }
 
-    const { error, count } = await supabase
+    // Look up the row first so we can clean up the linked storage object on
+    // success and return a clean 404 when the row is missing.
+    const { data: existing, error: fetchError } = await supabase
       .from('nutrition_logs')
-      .delete({ count: 'exact' })
+      .select('image_path')
       .eq('id', id)
       .eq('user_id', user.id)
+      .maybeSingle()
 
-    if (error) {
-      console.error('Database error (DELETE nutrition log):', error)
+    if (fetchError) {
+      console.error('Database error (DELETE nutrition log lookup):', fetchError)
       return NextResponse.json(
         { error: 'Failed to delete nutrition log' },
         { status: 500 }
       )
     }
 
-    if (count === 0) {
+    if (!existing) {
       return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
+
+    const { error: deleteError } = await supabase
+      .from('nutrition_logs')
+      .delete()
+      .eq('id', id)
+      .eq('user_id', user.id)
+
+    if (deleteError) {
+      console.error('Database error (DELETE nutrition log):', deleteError)
+      return NextResponse.json(
+        { error: 'Failed to delete nutrition log' },
+        { status: 500 }
+      )
+    }
+
+    // Best-effort: remove the associated meal image so it does not orphan in
+    // storage. A failure here must not fail the request — the row is gone.
+    if (existing.image_path) {
+      const { error: storageError } = await supabase.storage
+        .from('meal-images')
+        .remove([existing.image_path])
+      if (storageError) {
+        console.error(
+          'Storage cleanup failed (DELETE nutrition log):',
+          storageError
+        )
+      }
     }
 
     return NextResponse.json({ success: true })

--- a/src/app/api/nutrition-logs/[id]/route.ts
+++ b/src/app/api/nutrition-logs/[id]/route.ts
@@ -1,0 +1,181 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient } from '@/utils/supabase/server'
+
+interface RouteContext {
+  params: Promise<{ id: string }>
+}
+
+const UUID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+interface NutritionLogPatchBody {
+  food_items?: unknown
+  total_calories?: number
+  total_protein_g?: number
+  total_carbs_g?: number
+  total_fat_g?: number
+  total_fiber_g?: number
+  notes?: string | null
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+/**
+ * PATCH /api/nutrition-logs/[id]
+ *
+ * Allow the authenticated owner of a nutrition log to update editable fields
+ * (macros, food items, notes). RLS still enforces ownership at the DB layer;
+ * the explicit `eq('user_id', user.id)` filter is defense-in-depth.
+ */
+export async function PATCH(request: NextRequest, context: RouteContext) {
+  try {
+    const { id } = await context.params
+    if (!id || !UUID_REGEX.test(id)) {
+      return NextResponse.json({ error: 'Invalid id' }, { status: 400 })
+    }
+
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    let body: NutritionLogPatchBody
+    try {
+      body = await request.json()
+    } catch {
+      return NextResponse.json(
+        { error: 'Invalid JSON in request body' },
+        { status: 400 }
+      )
+    }
+
+    const updates: Record<string, unknown> = {}
+
+    if (body.food_items !== undefined) {
+      if (!Array.isArray(body.food_items)) {
+        return NextResponse.json(
+          { error: 'food_items must be an array' },
+          { status: 400 }
+        )
+      }
+      updates.food_items = body.food_items
+    }
+
+    const numericFields: (keyof NutritionLogPatchBody)[] = [
+      'total_calories',
+      'total_protein_g',
+      'total_carbs_g',
+      'total_fat_g',
+      'total_fiber_g',
+    ]
+    for (const field of numericFields) {
+      const value = body[field]
+      if (value === undefined) continue
+      if (!isNonNegativeNumber(value)) {
+        return NextResponse.json(
+          { error: `${field} must be a non-negative number` },
+          { status: 400 }
+        )
+      }
+      updates[field] = value
+    }
+
+    if (body.notes !== undefined) {
+      if (body.notes !== null && typeof body.notes !== 'string') {
+        return NextResponse.json(
+          { error: 'notes must be a string or null' },
+          { status: 400 }
+        )
+      }
+      updates.notes = body.notes
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return NextResponse.json(
+        { error: 'No updatable fields provided' },
+        { status: 400 }
+      )
+    }
+
+    const { data, error } = await supabase
+      .from('nutrition_logs')
+      .update(updates)
+      .eq('id', id)
+      .eq('user_id', user.id)
+      .select()
+      .single()
+
+    if (error) {
+      console.error('Database error (PATCH nutrition log):', error)
+      return NextResponse.json(
+        { error: 'Failed to update nutrition log' },
+        { status: 500 }
+      )
+    }
+
+    if (!data) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
+
+    return NextResponse.json({ success: true, data })
+  } catch (error) {
+    console.error('API error (PATCH nutrition log):', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+
+/**
+ * DELETE /api/nutrition-logs/[id]
+ */
+export async function DELETE(_request: NextRequest, context: RouteContext) {
+  try {
+    const { id } = await context.params
+    if (!id || !UUID_REGEX.test(id)) {
+      return NextResponse.json({ error: 'Invalid id' }, { status: 400 })
+    }
+
+    const supabase = await createClient()
+    const {
+      data: { user },
+      error: authError,
+    } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { error, count } = await supabase
+      .from('nutrition_logs')
+      .delete({ count: 'exact' })
+      .eq('id', id)
+      .eq('user_id', user.id)
+
+    if (error) {
+      console.error('Database error (DELETE nutrition log):', error)
+      return NextResponse.json(
+        { error: 'Failed to delete nutrition log' },
+        { status: 500 }
+      )
+    }
+
+    if (count === 0) {
+      return NextResponse.json({ error: 'Not found' }, { status: 404 })
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('API error (DELETE nutrition log):', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/calorie-tracker/dashboard/page.tsx
+++ b/src/app/calorie-tracker/dashboard/page.tsx
@@ -44,6 +44,9 @@ export default async function CalorieDashboardPage() {
 
   if (dbError) {
     console.error('Failed to load nutrition logs', dbError)
+    // Surface to the route error boundary instead of falling back to an empty
+    // array (which would misleadingly show "No meals logged yet").
+    throw new Error('Failed to load nutrition logs')
   }
 
   // Refresh signed URLs in a single batched call so thumbnails render even

--- a/src/app/calorie-tracker/dashboard/page.tsx
+++ b/src/app/calorie-tracker/dashboard/page.tsx
@@ -1,0 +1,111 @@
+import { redirect } from 'next/navigation'
+import Link from 'next/link'
+import { createClient } from '@/utils/supabase/server'
+import { NutritionLog } from '@/lib/nutrition-types'
+import { Card, CardContent } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { ArrowLeft } from 'lucide-react'
+import CalorieDashboard from '@/components/calorie-dashboard/CalorieDashboard'
+
+// Dashboards should always reflect the freshest logs.
+export const dynamic = 'force-dynamic'
+
+// Cap the lookback to keep payloads bounded; 30 days easily covers the
+// "Today / This Week / Last 7 Days" toggles plus a small margin.
+const LOOKBACK_DAYS = 30
+
+/**
+ * Server-rendered calorie dashboard. Fetches the authenticated user's recent
+ * nutrition logs (with fresh signed image URLs) and hands them to the client
+ * dashboard component for chart rendering, filtering, and CRUD.
+ */
+export default async function CalorieDashboardPage() {
+  const supabase = await createClient()
+  const {
+    data: { user },
+    error: authError,
+  } = await supabase.auth.getUser()
+
+  if (authError || !user) {
+    redirect('/login')
+  }
+
+  // Fetch logs from the last LOOKBACK_DAYS to power both today and weekly views
+  const since = new Date()
+  since.setDate(since.getDate() - LOOKBACK_DAYS)
+
+  const { data: rawLogs, error: dbError } = await supabase
+    .from('nutrition_logs')
+    .select(
+      'id, user_id, food_items, total_calories, total_protein_g, total_carbs_g, total_fat_g, total_fiber_g, image_url, image_path, confidence_score, notes, logged_at, created_at, updated_at'
+    )
+    .gte('logged_at', since.toISOString())
+    .order('logged_at', { ascending: false })
+
+  if (dbError) {
+    console.error('Failed to load nutrition logs', dbError)
+  }
+
+  // Refresh signed URLs in a single batched call so thumbnails render even
+  // when the stored URLs have expired. The logs were just fetched with RLS
+  // applied (auth.uid() = user_id), so each image_path is owned by `user`.
+  const imagePaths = (rawLogs ?? [])
+    .map((log) => log.image_path)
+    .filter((path): path is string => Boolean(path))
+
+  const signedUrlByPath = new Map<string, string>()
+  if (imagePaths.length > 0) {
+    const { data: signedResults } = await supabase.storage
+      .from('meal-images')
+      .createSignedUrls(imagePaths, 3600)
+    for (const result of signedResults ?? []) {
+      if (result.path && result.signedUrl) {
+        signedUrlByPath.set(result.path, result.signedUrl)
+      }
+    }
+  }
+
+  const logs: NutritionLog[] = (rawLogs ?? []).map((log) => ({
+    ...log,
+    image_url: log.image_path ? signedUrlByPath.get(log.image_path) : undefined,
+  })) as NutritionLog[]
+
+  return (
+    <div className="container mx-auto px-4 py-8">
+      <div className="max-w-5xl mx-auto space-y-6">
+        <div className="flex items-center justify-between">
+          <div>
+            <h1 className="text-2xl font-semibold tracking-tight">
+              Calorie Dashboard
+            </h1>
+            <p className="text-sm text-muted-foreground">
+              Daily and weekly nutrition at a glance.
+            </p>
+          </div>
+          <Button asChild variant="outline" size="sm">
+            <Link href="/calorie-tracker">
+              <ArrowLeft className="h-4 w-4" />
+              Back to logging
+            </Link>
+          </Button>
+        </div>
+
+        {logs.length === 0 ? (
+          <Card>
+            <CardContent className="py-12 text-center space-y-4">
+              <p className="text-base font-medium">No meals logged yet</p>
+              <p className="text-sm text-muted-foreground">
+                Log your first meal to see daily totals and trends here.
+              </p>
+              <Button asChild>
+                <Link href="/calorie-tracker">Log a meal</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        ) : (
+          <CalorieDashboard initialLogs={logs} />
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/app/calorie-tracker/page.tsx
+++ b/src/app/calorie-tracker/page.tsx
@@ -1,10 +1,12 @@
 import { Suspense } from 'react'
+import Link from 'next/link'
 import { createClient } from '@/utils/supabase/server'
 import { redirect } from 'next/navigation'
 import PhotoUpload from '@/components/calorie-tracker/PhotoUpload'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Alert, AlertDescription } from '@/components/ui/alert'
-import { CheckCircle } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { BarChart3, CheckCircle } from 'lucide-react'
 
 interface CalorieTrackerPageProps {
   searchParams: Promise<{ success?: string }>
@@ -45,11 +47,17 @@ export default async function CalorieTrackerPage({ searchParams }: CalorieTracke
           <CardHeader>
             <CardTitle>Calorie Tracker</CardTitle>
           </CardHeader>
-          <CardContent>
+          <CardContent className="space-y-4">
             <p className="text-gray-600">
-              Take a photo of your meal and let AI analyze the nutritional content, 
+              Take a photo of your meal and let AI analyze the nutritional content,
               or enter the information manually.
             </p>
+            <Button asChild variant="outline" size="sm">
+              <Link href="/calorie-tracker/dashboard">
+                <BarChart3 className="h-4 w-4" />
+                View calorie dashboard
+              </Link>
+            </Button>
           </CardContent>
         </Card>
 

--- a/src/components/calorie-dashboard/CalorieDashboard.tsx
+++ b/src/components/calorie-dashboard/CalorieDashboard.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useMemo, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { NutritionLog } from '@/lib/nutrition-types'
 import {
@@ -61,6 +61,12 @@ export default function CalorieDashboard({
   const router = useRouter()
   const [range, setRange] = useState<RangeKey>('today')
   const [logs, setLogs] = useState<NutritionLog[]>(initialLogs)
+
+  // Re-sync local state when the server prop changes (e.g. after
+  // `router.refresh()` returns updated server-rendered logs).
+  useEffect(() => {
+    setLogs(initialLogs)
+  }, [initialLogs])
 
   const totals = useMemo(() => {
     const { start, end } = rangeBounds(range)

--- a/src/components/calorie-dashboard/CalorieDashboard.tsx
+++ b/src/components/calorie-dashboard/CalorieDashboard.tsx
@@ -1,0 +1,125 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+import { NutritionLog } from '@/lib/nutrition-types'
+import {
+  buildDailySeries,
+  endOfLocalDay,
+  filterLogsInRange,
+  startOfLocalDay,
+  sumNutritionLogs,
+} from '@/lib/calorie-aggregations'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import SummaryStats from './SummaryStats'
+import CaloriesChart from './CaloriesChart'
+import MealHistory from './MealHistory'
+
+type RangeKey = 'today' | 'this-week' | 'last-7-days'
+
+const RANGE_OPTIONS: { key: RangeKey; label: string }[] = [
+  { key: 'today', label: 'Today' },
+  { key: 'this-week', label: 'This Week' },
+  { key: 'last-7-days', label: 'Last 7 Days' },
+]
+
+interface CalorieDashboardProps {
+  initialLogs: NutritionLog[]
+}
+
+/**
+ * Compute the inclusive [start, end] window for a given range key relative to
+ * the current local time. "This Week" starts on Monday — the same convention
+ * used for the weekly chart x-axis.
+ */
+function rangeBounds(range: RangeKey, now: Date = new Date()): {
+  start: Date
+  end: Date
+} {
+  const end = endOfLocalDay(now)
+  if (range === 'today') {
+    return { start: startOfLocalDay(now), end }
+  }
+  if (range === 'this-week') {
+    const start = startOfLocalDay(now)
+    // JS getDay(): Sunday = 0 ... Saturday = 6. Treat Monday as start of week.
+    const dayOfWeek = start.getDay()
+    const offsetToMonday = (dayOfWeek + 6) % 7
+    start.setDate(start.getDate() - offsetToMonday)
+    return { start, end }
+  }
+  // last-7-days
+  const start = startOfLocalDay(now)
+  start.setDate(start.getDate() - 6)
+  return { start, end }
+}
+
+export default function CalorieDashboard({
+  initialLogs,
+}: CalorieDashboardProps) {
+  const router = useRouter()
+  const [range, setRange] = useState<RangeKey>('today')
+  const [logs, setLogs] = useState<NutritionLog[]>(initialLogs)
+
+  const totals = useMemo(() => {
+    const { start, end } = rangeBounds(range)
+    return sumNutritionLogs(filterLogsInRange(logs, start, end))
+  }, [logs, range])
+
+  // The weekly chart always shows the trailing 7 days regardless of the
+  // summary range so trends remain visible even when the user is focused on
+  // today's totals.
+  const weeklySeries = useMemo(() => buildDailySeries(logs, 7), [logs])
+
+  const summaryLabel =
+    range === 'today'
+      ? "Today's Totals"
+      : range === 'this-week'
+        ? 'This Week (Mon-Today)'
+        : 'Last 7 Days'
+
+  const handleLogChanged = (updated: NutritionLog) => {
+    setLogs((prev) => prev.map((log) => (log.id === updated.id ? updated : log)))
+    router.refresh()
+  }
+
+  const handleLogDeleted = (id: string) => {
+    setLogs((prev) => prev.filter((log) => log.id !== id))
+    router.refresh()
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-wrap gap-2">
+        {RANGE_OPTIONS.map((opt) => (
+          <Button
+            key={opt.key}
+            variant={range === opt.key ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setRange(opt.key)}
+          >
+            {opt.label}
+          </Button>
+        ))}
+      </div>
+
+      <SummaryStats label={summaryLabel} totals={totals} />
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">7-Day Calorie Trend</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <CaloriesChart data={weeklySeries} />
+        </CardContent>
+      </Card>
+
+      <MealHistory
+        logs={logs}
+        onLogChanged={handleLogChanged}
+        onLogDeleted={handleLogDeleted}
+      />
+    </div>
+  )
+}

--- a/src/components/calorie-dashboard/CaloriesChart.tsx
+++ b/src/components/calorie-dashboard/CaloriesChart.tsx
@@ -1,0 +1,81 @@
+'use client'
+
+import { useMemo } from 'react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import { DailyTotals } from '@/lib/calorie-aggregations'
+
+interface CaloriesChartProps {
+  data: DailyTotals[]
+}
+
+function formatDayLabel(isoDate: string): string {
+  // ISO date keys are local-time `YYYY-MM-DD`; parse explicitly to avoid the
+  // UTC interpretation that `new Date('YYYY-MM-DD')` triggers.
+  const [year, month, day] = isoDate.split('-').map(Number)
+  if (!year || !month || !day) return isoDate
+  const d = new Date(year, month - 1, day)
+  return d.toLocaleDateString(undefined, { weekday: 'short', day: 'numeric' })
+}
+
+export default function CaloriesChart({ data }: CaloriesChartProps) {
+  const chartData = useMemo(
+    () =>
+      data.map((d) => ({
+        date: d.date,
+        label: formatDayLabel(d.date),
+        calories: Math.round(d.calories),
+      })),
+    [data]
+  )
+
+  const hasAny = chartData.some((d) => d.calories > 0)
+
+  if (!hasAny) {
+    return (
+      <div className="flex h-[220px] items-center justify-center text-sm text-muted-foreground">
+        No calorie data in the last 7 days yet.
+      </div>
+    )
+  }
+
+  return (
+    <div className="h-[260px] w-full">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart data={chartData} margin={{ top: 8, right: 8, bottom: 8, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" vertical={false} />
+          <XAxis
+            dataKey="label"
+            tickLine={false}
+            axisLine={false}
+            fontSize={12}
+          />
+          <YAxis
+            tickLine={false}
+            axisLine={false}
+            fontSize={12}
+            allowDecimals={false}
+            width={48}
+          />
+          <Tooltip
+            cursor={{ fillOpacity: 0.1 }}
+            formatter={(value: number) => [`${value} kcal`, 'Calories']}
+            labelFormatter={(label) => `${label}`}
+          />
+          <Bar
+            dataKey="calories"
+            fill="hsl(var(--primary))"
+            radius={[4, 4, 0, 0]}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  )
+}

--- a/src/components/calorie-dashboard/CaloriesChart.tsx
+++ b/src/components/calorie-dashboard/CaloriesChart.tsx
@@ -36,7 +36,9 @@ export default function CaloriesChart({ data }: CaloriesChartProps) {
     [data]
   )
 
-  const hasAny = chartData.some((d) => d.calories > 0)
+  // Use the raw, unrounded values so tiny positive totals (e.g. 0.4 kcal) do
+  // not collapse to 0 and trigger the empty state.
+  const hasAny = data.some((d) => d.calories > 0)
 
   if (!hasAny) {
     return (

--- a/src/components/calorie-dashboard/ConfirmDeleteDialog.tsx
+++ b/src/components/calorie-dashboard/ConfirmDeleteDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { NutritionLog } from '@/lib/nutrition-types'
 import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -39,11 +39,18 @@ export default function ConfirmDeleteDialog({
     }
   }
 
+  // Block backdrop/Escape dismissal while a delete request is in flight.
+  // Use a stable no-op so Modal's effect dependency doesn't re-fire each render.
+  const handleClose = useCallback(
+    () => (deleting ? undefined : onClose()),
+    [deleting, onClose]
+  )
+
   return (
     <Modal
       title="Delete this meal?"
       description="This permanently removes the entry from your log."
-      onClose={onClose}
+      onClose={handleClose}
       footer={
         <>
           <Button variant="ghost" onClick={onClose} disabled={deleting}>

--- a/src/components/calorie-dashboard/ConfirmDeleteDialog.tsx
+++ b/src/components/calorie-dashboard/ConfirmDeleteDialog.tsx
@@ -1,0 +1,75 @@
+'use client'
+
+import { useState } from 'react'
+import { NutritionLog } from '@/lib/nutrition-types'
+import { Button } from '@/components/ui/button'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import Modal from './Modal'
+
+interface ConfirmDeleteDialogProps {
+  log: NutritionLog
+  onClose: () => void
+  onDeleted: (id: string) => void
+}
+
+export default function ConfirmDeleteDialog({
+  log,
+  onClose,
+  onDeleted,
+}: ConfirmDeleteDialogProps) {
+  const [deleting, setDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleDelete = async () => {
+    setError(null)
+    setDeleting(true)
+    try {
+      const res = await fetch(`/api/nutrition-logs/${log.id}`, {
+        method: 'DELETE',
+      })
+      const payload = await res.json().catch(() => ({}))
+      if (!res.ok || !payload?.success) {
+        throw new Error(payload?.error || 'Failed to delete entry.')
+      }
+      onDeleted(log.id)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to delete entry.')
+    } finally {
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <Modal
+      title="Delete this meal?"
+      description="This permanently removes the entry from your log."
+      onClose={onClose}
+      footer={
+        <>
+          <Button variant="ghost" onClick={onClose} disabled={deleting}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            onClick={handleDelete}
+            disabled={deleting}
+          >
+            {deleting ? 'Deleting...' : 'Delete'}
+          </Button>
+        </>
+      }
+    >
+      {error ? (
+        <Alert>
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      ) : (
+        <p className="text-sm text-muted-foreground">
+          {log.food_items?.[0]?.name
+            ? `“${log.food_items[0].name}” will be permanently deleted.`
+            : 'This entry will be permanently deleted.'}
+        </p>
+      )}
+    </Modal>
+  )
+}

--- a/src/components/calorie-dashboard/MealDetailsDialog.tsx
+++ b/src/components/calorie-dashboard/MealDetailsDialog.tsx
@@ -1,0 +1,107 @@
+'use client'
+
+import Image from 'next/image'
+import { Pencil } from 'lucide-react'
+import { NutritionLog } from '@/lib/nutrition-types'
+import { Button } from '@/components/ui/button'
+import Modal from './Modal'
+import { formatDateTime, macro } from './format-helpers'
+
+interface MealDetailsDialogProps {
+  log: NutritionLog
+  onClose: () => void
+  onEdit: (log: NutritionLog) => void
+}
+
+export default function MealDetailsDialog({
+  log,
+  onClose,
+  onEdit,
+}: MealDetailsDialogProps) {
+  const macroStats: { label: string; value: string }[] = [
+    { label: 'Calories', value: String(Math.round(macro(log.total_calories))) },
+    { label: 'Protein', value: `${macro(log.total_protein_g).toFixed(1)}g` },
+    { label: 'Carbs', value: `${macro(log.total_carbs_g).toFixed(1)}g` },
+    { label: 'Fat', value: `${macro(log.total_fat_g).toFixed(1)}g` },
+  ]
+
+  return (
+    <Modal
+      title="Meal details"
+      description={log.logged_at ? formatDateTime(log.logged_at) : undefined}
+      onClose={onClose}
+      footer={
+        <>
+          <Button variant="ghost" onClick={onClose}>
+            Close
+          </Button>
+          <Button onClick={() => onEdit(log)}>
+            <Pencil className="h-4 w-4" />
+            Edit
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        {log.image_url ? (
+          <div className="relative aspect-video w-full overflow-hidden rounded-md bg-muted">
+            <Image
+              src={log.image_url}
+              alt="Meal photo"
+              fill
+              sizes="(max-width: 640px) 100vw, 480px"
+              className="object-cover"
+              unoptimized
+            />
+          </div>
+        ) : null}
+
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4 text-center">
+          {macroStats.map((stat) => (
+            <div key={stat.label} className="rounded-lg border p-3">
+              <div className="text-xs uppercase text-muted-foreground">
+                {stat.label}
+              </div>
+              <div className="text-lg font-semibold">{stat.value}</div>
+            </div>
+          ))}
+        </div>
+
+        {log.food_items?.length ? (
+          <div>
+            <h3 className="mb-2 text-sm font-semibold">Food items</h3>
+            <ul className="divide-y rounded-md border">
+              {log.food_items.map((item, idx) => (
+                <li
+                  key={item.id ?? idx}
+                  className="flex justify-between px-3 py-2 text-sm"
+                >
+                  <span className="truncate">
+                    {item.name || `Item ${idx + 1}`}
+                    {item.serving_size ? (
+                      <span className="ml-1 text-muted-foreground">
+                        ({item.serving_size})
+                      </span>
+                    ) : null}
+                  </span>
+                  <span className="ml-2 shrink-0 text-muted-foreground">
+                    {Math.round(macro(item.calories))} kcal
+                  </span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+
+        {log.notes ? (
+          <div>
+            <h3 className="mb-1 text-sm font-semibold">Notes</h3>
+            <p className="text-sm text-muted-foreground whitespace-pre-wrap">
+              {log.notes}
+            </p>
+          </div>
+        ) : null}
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/calorie-dashboard/MealEditDialog.tsx
+++ b/src/components/calorie-dashboard/MealEditDialog.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import { useState } from 'react'
+import { NutritionLog } from '@/lib/nutrition-types'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Textarea } from '@/components/ui/textarea'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import Modal from './Modal'
+import { macro } from './format-helpers'
+
+interface MealEditDialogProps {
+  log: NutritionLog
+  onClose: () => void
+  onSaved: (updated: NutritionLog) => void
+}
+
+interface FormState {
+  name: string
+  calories: string
+  protein_g: string
+  carbs_g: string
+  fat_g: string
+  notes: string
+}
+
+type MacroField = 'calories' | 'protein_g' | 'carbs_g' | 'fat_g'
+
+const MACRO_FIELDS: { key: MacroField; label: string; step: string }[] = [
+  { key: 'calories', label: 'Calories', step: '1' },
+  { key: 'protein_g', label: 'Protein (g)', step: '0.1' },
+  { key: 'carbs_g', label: 'Carbs (g)', step: '0.1' },
+  { key: 'fat_g', label: 'Fat (g)', step: '0.1' },
+]
+
+function initialForm(log: NutritionLog): FormState {
+  return {
+    name: log.food_items?.[0]?.name ?? '',
+    calories: String(Math.round(macro(log.total_calories))),
+    protein_g: String(macro(log.total_protein_g)),
+    carbs_g: String(macro(log.total_carbs_g)),
+    fat_g: String(macro(log.total_fat_g)),
+    notes: log.notes ?? '',
+  }
+}
+
+function parseNonNegativeNumber(value: string): number | null {
+  const trimmed = value.trim()
+  if (trimmed === '') return null
+  const num = Number(trimmed)
+  if (!Number.isFinite(num) || num < 0) return null
+  return num
+}
+
+export default function MealEditDialog({
+  log,
+  onClose,
+  onSaved,
+}: MealEditDialogProps) {
+  const [form, setForm] = useState<FormState>(() => initialForm(log))
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const update = (field: keyof FormState, value: string) =>
+    setForm((prev) => ({ ...prev, [field]: value }))
+
+  const handleSave = async () => {
+    setError(null)
+
+    const parsed: Record<MacroField, number | null> = {
+      calories: parseNonNegativeNumber(form.calories),
+      protein_g: parseNonNegativeNumber(form.protein_g),
+      carbs_g: parseNonNegativeNumber(form.carbs_g),
+      fat_g: parseNonNegativeNumber(form.fat_g),
+    }
+
+    if (Object.values(parsed).some((v) => v === null)) {
+      setError('All macro fields must be non-negative numbers.')
+      return
+    }
+    const { calories, protein_g, carbs_g, fat_g } = parsed as Record<
+      MacroField,
+      number
+    >
+
+    // Keep the meal title in sync by updating the first food item's name. If
+    // the log has no food items, create a placeholder so the schema's NOT NULL
+    // food_items column stays valid.
+    const trimmedName = form.name.trim()
+    const updatedItems = log.food_items?.length
+      ? log.food_items.map((item, idx) =>
+          idx === 0 ? { ...item, name: trimmedName || item.name } : item
+        )
+      : [
+          {
+            id: '1',
+            name: trimmedName || 'Meal',
+            calories,
+            protein_g,
+            carbs_g,
+            fat_g,
+            fiber_g: macro(log.total_fiber_g),
+          },
+        ]
+
+    setSaving(true)
+    try {
+      const res = await fetch(`/api/nutrition-logs/${log.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          food_items: updatedItems,
+          total_calories: calories,
+          total_protein_g: protein_g,
+          total_carbs_g: carbs_g,
+          total_fat_g: fat_g,
+          notes: form.notes.trim() || null,
+        }),
+      })
+
+      const payload = await res.json().catch(() => ({}))
+      if (!res.ok || !payload?.success) {
+        throw new Error(payload?.error || 'Failed to save changes.')
+      }
+
+      // Preserve the existing signed image_url since the API response only
+      // contains the stored image_url (which may be expired).
+      onSaved({ ...payload.data, image_url: log.image_url })
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save changes.')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <Modal
+      title="Edit meal"
+      description="Update the macros, name, or notes for this entry."
+      onClose={onClose}
+      footer={
+        <>
+          <Button variant="ghost" onClick={onClose} disabled={saving}>
+            Cancel
+          </Button>
+          <Button onClick={handleSave} disabled={saving}>
+            {saving ? 'Saving...' : 'Save changes'}
+          </Button>
+        </>
+      }
+    >
+      <div className="space-y-4">
+        {error ? (
+          <Alert>
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        ) : null}
+
+        <div className="space-y-1">
+          <Label htmlFor="meal-name">Name</Label>
+          <Input
+            id="meal-name"
+            value={form.name}
+            onChange={(e) => update('name', e.target.value)}
+            placeholder="e.g. Grilled chicken bowl"
+          />
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          {MACRO_FIELDS.map((field) => (
+            <div key={field.key} className="space-y-1">
+              <Label htmlFor={`meal-${field.key}`}>{field.label}</Label>
+              <Input
+                id={`meal-${field.key}`}
+                type="number"
+                inputMode="decimal"
+                min="0"
+                step={field.step}
+                value={form[field.key]}
+                onChange={(e) => update(field.key, e.target.value)}
+              />
+            </div>
+          ))}
+        </div>
+
+        <div className="space-y-1">
+          <Label htmlFor="meal-notes">Notes</Label>
+          <Textarea
+            id="meal-notes"
+            value={form.notes}
+            onChange={(e) => update('notes', e.target.value)}
+            placeholder="Optional notes"
+          />
+        </div>
+      </div>
+    </Modal>
+  )
+}

--- a/src/components/calorie-dashboard/MealEditDialog.tsx
+++ b/src/components/calorie-dashboard/MealEditDialog.tsx
@@ -84,13 +84,25 @@ export default function MealEditDialog({
       number
     >
 
-    // Keep the meal title in sync by updating the first food item's name. If
-    // the log has no food items, create a placeholder so the schema's NOT NULL
-    // food_items column stays valid.
+    // Keep the meal title and first item's macros in sync with the totals so
+    // the per-item view does not drift from the new totals. If the log has no
+    // food items, create a placeholder so the schema's NOT NULL food_items
+    // column stays valid.
     const trimmedName = form.name.trim()
+    const fiber_g = macro(log.total_fiber_g)
     const updatedItems = log.food_items?.length
       ? log.food_items.map((item, idx) =>
-          idx === 0 ? { ...item, name: trimmedName || item.name } : item
+          idx === 0
+            ? {
+                ...item,
+                name: trimmedName || item.name,
+                calories,
+                protein_g,
+                carbs_g,
+                fat_g,
+                fiber_g,
+              }
+            : item
         )
       : [
           {
@@ -100,7 +112,7 @@ export default function MealEditDialog({
             protein_g,
             carbs_g,
             fat_g,
-            fiber_g: macro(log.total_fiber_g),
+            fiber_g,
           },
         ]
 

--- a/src/components/calorie-dashboard/MealHistory.tsx
+++ b/src/components/calorie-dashboard/MealHistory.tsx
@@ -1,0 +1,171 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import Image from 'next/image'
+import { Eye, Pencil, Trash2, Utensils } from 'lucide-react'
+import { NutritionLog } from '@/lib/nutrition-types'
+import { groupLogsByDay } from '@/lib/calorie-aggregations'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import MealDetailsDialog from './MealDetailsDialog'
+import MealEditDialog from './MealEditDialog'
+import ConfirmDeleteDialog from './ConfirmDeleteDialog'
+import {
+  formatDayHeading,
+  formatTime,
+  logDisplayName,
+  macro,
+} from './format-helpers'
+
+interface MealHistoryProps {
+  logs: NutritionLog[]
+  onLogChanged: (log: NutritionLog) => void
+  onLogDeleted: (id: string) => void
+}
+
+export default function MealHistory({
+  logs,
+  onLogChanged,
+  onLogDeleted,
+}: MealHistoryProps) {
+  const [viewing, setViewing] = useState<NutritionLog | null>(null)
+  const [editing, setEditing] = useState<NutritionLog | null>(null)
+  const [deleting, setDeleting] = useState<NutritionLog | null>(null)
+
+  const grouped = useMemo(() => groupLogsByDay(logs), [logs])
+
+  if (grouped.size === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Meal History</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground">No meals logged yet.</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Meal History</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-6">
+          {Array.from(grouped.entries()).map(([dayKey, dayLogs]) => (
+            <section key={dayKey} className="space-y-2">
+              <h3 className="text-sm font-semibold text-muted-foreground">
+                {formatDayHeading(dayKey)}
+              </h3>
+              <ul className="divide-y rounded-lg border">
+                {dayLogs.map((log) => (
+                  <li
+                    key={log.id}
+                    className="flex flex-col sm:flex-row sm:items-center gap-3 p-3"
+                  >
+                    <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-md bg-muted">
+                      {log.image_url ? (
+                        <Image
+                          src={log.image_url}
+                          alt={logDisplayName(log)}
+                          fill
+                          sizes="64px"
+                          className="object-cover"
+                          unoptimized
+                        />
+                      ) : (
+                        <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+                          <Utensils className="h-6 w-6" />
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="min-w-0 flex-1">
+                      <div className="flex items-center gap-2">
+                        <p className="truncate font-medium">
+                          {logDisplayName(log)}
+                        </p>
+                        <Badge variant="secondary" className="shrink-0">
+                          {Math.round(macro(log.total_calories))} kcal
+                        </Badge>
+                      </div>
+                      <p className="mt-0.5 text-xs text-muted-foreground">
+                        P {macro(log.total_protein_g).toFixed(0)}g · C{' '}
+                        {macro(log.total_carbs_g).toFixed(0)}g · F{' '}
+                        {macro(log.total_fat_g).toFixed(0)}g
+                        {log.logged_at ? ` · ${formatTime(log.logged_at)}` : ''}
+                      </p>
+                    </div>
+
+                    <div className="flex shrink-0 gap-1">
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="View meal"
+                        onClick={() => setViewing(log)}
+                      >
+                        <Eye className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Edit meal"
+                        onClick={() => setEditing(log)}
+                      >
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        aria-label="Delete meal"
+                        onClick={() => setDeleting(log)}
+                      >
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </CardContent>
+      </Card>
+
+      {viewing ? (
+        <MealDetailsDialog
+          log={viewing}
+          onClose={() => setViewing(null)}
+          onEdit={(log) => {
+            setViewing(null)
+            setEditing(log)
+          }}
+        />
+      ) : null}
+
+      {editing ? (
+        <MealEditDialog
+          log={editing}
+          onClose={() => setEditing(null)}
+          onSaved={(updated) => {
+            setEditing(null)
+            onLogChanged(updated)
+          }}
+        />
+      ) : null}
+
+      {deleting ? (
+        <ConfirmDeleteDialog
+          log={deleting}
+          onClose={() => setDeleting(null)}
+          onDeleted={(id) => {
+            setDeleting(null)
+            onLogDeleted(id)
+          }}
+        />
+      ) : null}
+    </>
+  )
+}

--- a/src/components/calorie-dashboard/Modal.tsx
+++ b/src/components/calorie-dashboard/Modal.tsx
@@ -1,0 +1,84 @@
+'use client'
+
+import { useEffect } from 'react'
+import { X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface ModalProps {
+  title: string
+  description?: string
+  children: React.ReactNode
+  onClose: () => void
+  /** Optional footer (e.g. action buttons). */
+  footer?: React.ReactNode
+}
+
+/**
+ * Lightweight focus-and-escape-aware modal. We avoid pulling in @radix-ui/react-dialog
+ * since the rest of the codebase has not adopted it; this keeps the bundle
+ * lean while still providing the basics: backdrop, escape-to-close, scroll
+ * lock, and an accessible heading.
+ */
+export default function Modal({
+  title,
+  description,
+  children,
+  onClose,
+  footer,
+}: ModalProps) {
+  useEffect(() => {
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    const previousOverflow = document.body.style.overflow
+    document.body.style.overflow = 'hidden'
+    return () => {
+      document.removeEventListener('keydown', onKeyDown)
+      document.body.style.overflow = previousOverflow
+    }
+  }, [onClose])
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="modal-title"
+    >
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div className="relative z-10 w-full sm:max-w-lg max-h-[90vh] overflow-y-auto rounded-t-xl sm:rounded-xl bg-background shadow-lg">
+        <div className="flex items-start justify-between gap-3 border-b px-5 py-4">
+          <div>
+            <h2 id="modal-title" className="text-base font-semibold">
+              {title}
+            </h2>
+            {description ? (
+              <p className="mt-0.5 text-sm text-muted-foreground">
+                {description}
+              </p>
+            ) : null}
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onClose}
+            aria-label="Close"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+        <div className="px-5 py-4">{children}</div>
+        {footer ? (
+          <div className="flex flex-wrap justify-end gap-2 border-t px-5 py-3">
+            {footer}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  )
+}

--- a/src/components/calorie-dashboard/Modal.tsx
+++ b/src/components/calorie-dashboard/Modal.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useEffect } from 'react'
+import { useEffect, useId } from 'react'
 import { X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
@@ -26,6 +26,9 @@ export default function Modal({
   onClose,
   footer,
 }: ModalProps) {
+  const titleId = useId()
+  const descriptionId = useId()
+
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose()
@@ -44,7 +47,8 @@ export default function Modal({
       className="fixed inset-0 z-50 flex items-end sm:items-center justify-center p-0 sm:p-4"
       role="dialog"
       aria-modal="true"
-      aria-labelledby="modal-title"
+      aria-labelledby={titleId}
+      aria-describedby={description ? descriptionId : undefined}
     >
       <div
         className="absolute inset-0 bg-black/50"
@@ -54,11 +58,14 @@ export default function Modal({
       <div className="relative z-10 w-full sm:max-w-lg max-h-[90vh] overflow-y-auto rounded-t-xl sm:rounded-xl bg-background shadow-lg">
         <div className="flex items-start justify-between gap-3 border-b px-5 py-4">
           <div>
-            <h2 id="modal-title" className="text-base font-semibold">
+            <h2 id={titleId} className="text-base font-semibold">
               {title}
             </h2>
             {description ? (
-              <p className="mt-0.5 text-sm text-muted-foreground">
+              <p
+                id={descriptionId}
+                className="mt-0.5 text-sm text-muted-foreground"
+              >
                 {description}
               </p>
             ) : null}

--- a/src/components/calorie-dashboard/SummaryStats.tsx
+++ b/src/components/calorie-dashboard/SummaryStats.tsx
@@ -1,0 +1,53 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { NutritionTotals } from '@/lib/calorie-aggregations'
+import { formatNumber } from './format-helpers'
+
+interface SummaryStatsProps {
+  label: string
+  totals: NutritionTotals
+}
+
+interface Stat {
+  label: string
+  value: string
+  unit?: string
+}
+
+export default function SummaryStats({ label, totals }: SummaryStatsProps) {
+  const stats: Stat[] = [
+    { label: 'Calories', value: formatNumber(totals.calories), unit: 'kcal' },
+    { label: 'Protein', value: formatNumber(totals.protein_g, 1), unit: 'g' },
+    { label: 'Carbs', value: formatNumber(totals.carbs_g, 1), unit: 'g' },
+    { label: 'Fat', value: formatNumber(totals.fat_g, 1), unit: 'g' },
+  ]
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{label}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+          {stats.map((stat) => (
+            <div
+              key={stat.label}
+              className="rounded-lg border bg-card p-4 text-center"
+            >
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">
+                {stat.label}
+              </div>
+              <div className="mt-1 text-2xl font-semibold">
+                {stat.value}
+                {stat.unit ? (
+                  <span className="ml-1 text-sm font-normal text-muted-foreground">
+                    {stat.unit}
+                  </span>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/components/calorie-dashboard/format-helpers.ts
+++ b/src/components/calorie-dashboard/format-helpers.ts
@@ -1,0 +1,66 @@
+import { NutritionLog } from '@/lib/nutrition-types'
+import { startOfLocalDay, toLocalDateKey } from '@/lib/calorie-aggregations'
+
+/** Coerce a possibly-null/undefined macro value to a finite number (or 0). */
+export function macro(value: number | null | undefined): number {
+  const n = Number(value)
+  return Number.isFinite(n) ? n : 0
+}
+
+/** Friendly display name for a meal — uses the first food item's name. */
+export function logDisplayName(log: NutritionLog): string {
+  const items = log.food_items ?? []
+  const names = items
+    .map((item) => item.name?.trim())
+    .filter((n): n is string => Boolean(n))
+  if (names.length === 0) return 'Meal'
+  if (names.length === 1) return names[0]
+  return `${names[0]} +${names.length - 1} more`
+}
+
+/** Today / Yesterday / "Mon, Apr 5" — accepts a local-day key. */
+export function formatDayHeading(isoDate: string): string {
+  const [year, month, day] = isoDate.split('-').map(Number)
+  if (!year || !month || !day) return isoDate
+  const date = new Date(year, month - 1, day)
+  const today = startOfLocalDay(new Date())
+  const yesterday = new Date(today)
+  yesterday.setDate(today.getDate() - 1)
+
+  if (toLocalDateKey(date) === toLocalDateKey(today)) return 'Today'
+  if (toLocalDateKey(date) === toLocalDateKey(yesterday)) return 'Yesterday'
+  return date.toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'short',
+    day: 'numeric',
+  })
+}
+
+/** "9:42 AM" or "" for an invalid timestamp. */
+export function formatTime(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return ''
+  return d.toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  })
+}
+
+/** "Apr 5, 2026, 9:42 AM" or the raw input on parse failure. */
+export function formatDateTime(iso: string): string {
+  const d = new Date(iso)
+  if (Number.isNaN(d.getTime())) return iso
+  return d.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  })
+}
+
+/** Locale-aware number formatter with fixed fraction digits. */
+export function formatNumber(n: number, fractionDigits = 0): string {
+  if (!Number.isFinite(n)) return '0'
+  return n.toLocaleString(undefined, {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  })
+}

--- a/src/lib/calorie-aggregations.test.ts
+++ b/src/lib/calorie-aggregations.test.ts
@@ -174,6 +174,19 @@ describe('groupLogsByDay', () => {
   it('returns empty map for no logs', () => {
     expect(groupLogsByDay([]).size).toBe(0)
   })
+
+  it('skips logs with invalid logged_at instead of producing NaN keys', () => {
+    const logs = [
+      makeLog({ id: 'bad', logged_at: 'not-a-date' }),
+      makeLog({ id: 'good', logged_at: new Date(2026, 3, 5, 9).toISOString() }),
+    ]
+    const grouped = groupLogsByDay(logs)
+    const keys = Array.from(grouped.keys())
+    expect(keys).toEqual(['2026-04-05'])
+    for (const key of keys) {
+      expect(key).not.toContain('NaN')
+    }
+  })
 })
 
 describe('buildDailySeries', () => {

--- a/src/lib/calorie-aggregations.test.ts
+++ b/src/lib/calorie-aggregations.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, expect } from '@jest/globals'
+import {
+  buildDailySeries,
+  filterLogsInRange,
+  getTodayTotals,
+  groupLogsByDay,
+  startOfLocalDay,
+  endOfLocalDay,
+  sumNutritionLogs,
+  toLocalDateKey,
+} from './calorie-aggregations'
+import { NutritionLog } from './nutrition-types'
+
+function makeLog(overrides: Partial<NutritionLog> = {}): NutritionLog {
+  return {
+    id: overrides.id ?? Math.random().toString(),
+    user_id: 'user-1',
+    food_items: [],
+    total_calories: 0,
+    total_protein_g: 0,
+    total_carbs_g: 0,
+    total_fat_g: 0,
+    total_fiber_g: 0,
+    logged_at: new Date().toISOString(),
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe('toLocalDateKey', () => {
+  it('formats a date as YYYY-MM-DD', () => {
+    const date = new Date(2026, 3, 5, 14, 30) // April 5, 2026
+    expect(toLocalDateKey(date)).toBe('2026-04-05')
+  })
+
+  it('zero-pads months and days', () => {
+    const date = new Date(2026, 0, 1)
+    expect(toLocalDateKey(date)).toBe('2026-01-01')
+  })
+})
+
+describe('startOfLocalDay / endOfLocalDay', () => {
+  it('returns midnight for startOfLocalDay', () => {
+    const date = new Date(2026, 3, 5, 14, 30, 45, 123)
+    const start = startOfLocalDay(date)
+    expect(start.getHours()).toBe(0)
+    expect(start.getMinutes()).toBe(0)
+    expect(start.getSeconds()).toBe(0)
+    expect(start.getMilliseconds()).toBe(0)
+    expect(start.getDate()).toBe(5)
+  })
+
+  it('returns 23:59:59.999 for endOfLocalDay', () => {
+    const date = new Date(2026, 3, 5, 14, 30)
+    const end = endOfLocalDay(date)
+    expect(end.getHours()).toBe(23)
+    expect(end.getMinutes()).toBe(59)
+    expect(end.getSeconds()).toBe(59)
+    expect(end.getMilliseconds()).toBe(999)
+  })
+
+  it('does not mutate the input date', () => {
+    const date = new Date(2026, 3, 5, 14, 30)
+    const original = date.getTime()
+    startOfLocalDay(date)
+    endOfLocalDay(date)
+    expect(date.getTime()).toBe(original)
+  })
+})
+
+describe('sumNutritionLogs', () => {
+  it('returns zeros for empty array', () => {
+    expect(sumNutritionLogs([])).toEqual({
+      calories: 0,
+      protein_g: 0,
+      carbs_g: 0,
+      fat_g: 0,
+      fiber_g: 0,
+    })
+  })
+
+  it('sums macros across multiple logs', () => {
+    const logs = [
+      makeLog({
+        total_calories: 500,
+        total_protein_g: 20,
+        total_carbs_g: 50,
+        total_fat_g: 15,
+        total_fiber_g: 5,
+      }),
+      makeLog({
+        total_calories: 300,
+        total_protein_g: 10,
+        total_carbs_g: 30,
+        total_fat_g: 8,
+        total_fiber_g: 3,
+      }),
+    ]
+    expect(sumNutritionLogs(logs)).toEqual({
+      calories: 800,
+      protein_g: 30,
+      carbs_g: 80,
+      fat_g: 23,
+      fiber_g: 8,
+    })
+  })
+
+  it('coerces undefined/null fields to zero', () => {
+    const logs = [
+      makeLog({
+        total_calories: 100,
+        total_protein_g: undefined as unknown as number,
+        total_fiber_g: null as unknown as number,
+      }),
+    ]
+    const totals = sumNutritionLogs(logs)
+    expect(totals.calories).toBe(100)
+    expect(totals.protein_g).toBe(0)
+    expect(totals.fiber_g).toBe(0)
+  })
+})
+
+describe('filterLogsInRange', () => {
+  it('includes logs at the boundaries', () => {
+    const start = new Date(2026, 3, 5, 0, 0, 0, 0)
+    const end = new Date(2026, 3, 5, 23, 59, 59, 999)
+    const logs = [
+      makeLog({ id: 'a', logged_at: start.toISOString() }),
+      makeLog({ id: 'b', logged_at: end.toISOString() }),
+      makeLog({
+        id: 'c',
+        logged_at: new Date(2026, 3, 6, 0, 0, 0, 1).toISOString(),
+      }),
+    ]
+    const filtered = filterLogsInRange(logs, start, end)
+    expect(filtered.map((l) => l.id).sort()).toEqual(['a', 'b'])
+  })
+
+  it('returns empty for no matches', () => {
+    const start = new Date(2026, 3, 5)
+    const end = new Date(2026, 3, 5, 23, 59)
+    const logs = [
+      makeLog({ logged_at: new Date(2026, 3, 1).toISOString() }),
+    ]
+    expect(filterLogsInRange(logs, start, end)).toEqual([])
+  })
+
+  it('skips logs with invalid logged_at', () => {
+    const start = new Date(2026, 3, 5)
+    const end = new Date(2026, 3, 5, 23, 59)
+    const logs = [makeLog({ logged_at: 'not-a-date' })]
+    expect(filterLogsInRange(logs, start, end)).toEqual([])
+  })
+})
+
+describe('groupLogsByDay', () => {
+  it('groups logs by local day, newest day first', () => {
+    const logs = [
+      makeLog({ id: 'older', logged_at: new Date(2026, 3, 3, 12).toISOString() }),
+      makeLog({ id: 'newer', logged_at: new Date(2026, 3, 5, 9).toISOString() }),
+      makeLog({ id: 'newer-later', logged_at: new Date(2026, 3, 5, 18).toISOString() }),
+    ]
+    const grouped = groupLogsByDay(logs)
+    const keys = Array.from(grouped.keys())
+    expect(keys).toEqual(['2026-04-05', '2026-04-03'])
+    // Within a day, newest log first
+    expect(grouped.get('2026-04-05')!.map((l) => l.id)).toEqual([
+      'newer-later',
+      'newer',
+    ])
+  })
+
+  it('returns empty map for no logs', () => {
+    expect(groupLogsByDay([]).size).toBe(0)
+  })
+})
+
+describe('buildDailySeries', () => {
+  it('returns N contiguous days ending on endDate', () => {
+    const end = new Date(2026, 3, 27)
+    const series = buildDailySeries([], 7, end)
+    expect(series).toHaveLength(7)
+    expect(series[0].date).toBe('2026-04-21')
+    expect(series[6].date).toBe('2026-04-27')
+    for (const day of series) {
+      expect(day.calories).toBe(0)
+      expect(day.count).toBe(0)
+    }
+  })
+
+  it('aggregates logs into the correct day buckets', () => {
+    const end = new Date(2026, 3, 27, 12)
+    const logs = [
+      makeLog({
+        total_calories: 500,
+        logged_at: new Date(2026, 3, 27, 8).toISOString(),
+      }),
+      makeLog({
+        total_calories: 200,
+        logged_at: new Date(2026, 3, 27, 18).toISOString(),
+      }),
+      makeLog({
+        total_calories: 400,
+        logged_at: new Date(2026, 3, 25, 10).toISOString(),
+      }),
+    ]
+    const series = buildDailySeries(logs, 7, end)
+    const today = series.find((d) => d.date === '2026-04-27')!
+    const twoDaysAgo = series.find((d) => d.date === '2026-04-25')!
+    expect(today.calories).toBe(700)
+    expect(today.count).toBe(2)
+    expect(twoDaysAgo.calories).toBe(400)
+    expect(twoDaysAgo.count).toBe(1)
+  })
+
+  it('returns empty array for non-positive days', () => {
+    expect(buildDailySeries([], 0)).toEqual([])
+    expect(buildDailySeries([], -1)).toEqual([])
+  })
+
+  it('ignores logs outside the window', () => {
+    const end = new Date(2026, 3, 27)
+    const logs = [
+      makeLog({
+        total_calories: 9999,
+        logged_at: new Date(2026, 2, 1).toISOString(),
+      }),
+    ]
+    const series = buildDailySeries(logs, 7, end)
+    const total = series.reduce((sum, d) => sum + d.calories, 0)
+    expect(total).toBe(0)
+  })
+})
+
+describe('getTodayTotals', () => {
+  it('only counts logs from today (local)', () => {
+    const now = new Date(2026, 3, 27, 14)
+    const logs = [
+      makeLog({
+        total_calories: 500,
+        logged_at: new Date(2026, 3, 27, 8).toISOString(),
+      }),
+      makeLog({
+        total_calories: 300,
+        logged_at: new Date(2026, 3, 26, 23).toISOString(),
+      }),
+    ]
+    const totals = getTodayTotals(logs, now)
+    expect(totals.calories).toBe(500)
+  })
+})

--- a/src/lib/calorie-aggregations.ts
+++ b/src/lib/calorie-aggregations.ts
@@ -1,0 +1,165 @@
+import { NutritionLog } from './nutrition-types'
+
+export interface NutritionTotals {
+  calories: number
+  protein_g: number
+  carbs_g: number
+  fat_g: number
+  fiber_g: number
+}
+
+export interface DailyTotals extends NutritionTotals {
+  /** ISO date string in `YYYY-MM-DD` format (local time). */
+  date: string
+  count: number
+}
+
+export const EMPTY_TOTALS: NutritionTotals = {
+  calories: 0,
+  protein_g: 0,
+  carbs_g: 0,
+  fat_g: 0,
+  fiber_g: 0,
+}
+
+/**
+ * Format a Date as `YYYY-MM-DD` using its local-time fields.
+ *
+ * The dashboard groups entries by the user's local day, so we deliberately
+ * avoid `toISOString()` which would shift entries near midnight to the wrong
+ * day in non-UTC timezones.
+ */
+export function toLocalDateKey(date: Date): string {
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+/**
+ * Returns midnight (local time) for the day of the supplied date.
+ */
+export function startOfLocalDay(date: Date): Date {
+  const copy = new Date(date)
+  copy.setHours(0, 0, 0, 0)
+  return copy
+}
+
+/**
+ * Returns the end of the supplied date in local time (23:59:59.999).
+ */
+export function endOfLocalDay(date: Date): Date {
+  const copy = new Date(date)
+  copy.setHours(23, 59, 59, 999)
+  return copy
+}
+
+/**
+ * Sum totals across an arbitrary list of nutrition logs.
+ *
+ * Coerces missing/null macronutrient fields to 0 so partial logs (for
+ * example, calories-only manual entries) never produce `NaN` totals.
+ */
+export function sumNutritionLogs(logs: NutritionLog[]): NutritionTotals {
+  return logs.reduce<NutritionTotals>(
+    (totals, log) => ({
+      calories: totals.calories + (Number(log.total_calories) || 0),
+      protein_g: totals.protein_g + (Number(log.total_protein_g) || 0),
+      carbs_g: totals.carbs_g + (Number(log.total_carbs_g) || 0),
+      fat_g: totals.fat_g + (Number(log.total_fat_g) || 0),
+      fiber_g: totals.fiber_g + (Number(log.total_fiber_g) || 0),
+    }),
+    { ...EMPTY_TOTALS }
+  )
+}
+
+/**
+ * Filter nutrition logs whose `logged_at` falls inside the inclusive range.
+ */
+export function filterLogsInRange(
+  logs: NutritionLog[],
+  start: Date,
+  end: Date
+): NutritionLog[] {
+  const startMs = start.getTime()
+  const endMs = end.getTime()
+  return logs.filter((log) => {
+    const ts = new Date(log.logged_at).getTime()
+    return !Number.isNaN(ts) && ts >= startMs && ts <= endMs
+  })
+}
+
+/**
+ * Bucket logs by local-day key. Insertion order matches input order.
+ */
+function bucketLogsByDay(logs: NutritionLog[]): Map<string, NutritionLog[]> {
+  const buckets = new Map<string, NutritionLog[]>()
+  for (const log of logs) {
+    const key = toLocalDateKey(new Date(log.logged_at))
+    const bucket = buckets.get(key)
+    if (bucket) bucket.push(log)
+    else buckets.set(key, [log])
+  }
+  return buckets
+}
+
+/**
+ * Group nutrition logs by the local-time day of `logged_at`. Days are
+ * returned newest-first; entries within each day are also newest-first.
+ */
+export function groupLogsByDay(
+  logs: NutritionLog[]
+): Map<string, NutritionLog[]> {
+  const buckets = bucketLogsByDay(logs)
+  for (const bucket of buckets.values()) {
+    bucket.sort(
+      (a, b) =>
+        new Date(b.logged_at).getTime() - new Date(a.logged_at).getTime()
+    )
+  }
+  return new Map(
+    Array.from(buckets.entries()).sort(([a], [b]) => (a < b ? 1 : -1))
+  )
+}
+
+/**
+ * Build a contiguous N-day series ending on `endDate` (local time), filling
+ * missing days with zero totals so charts render without gaps.
+ */
+export function buildDailySeries(
+  logs: NutritionLog[],
+  days: number,
+  endDate: Date = new Date()
+): DailyTotals[] {
+  if (days <= 0) return []
+
+  const end = startOfLocalDay(endDate)
+  const buckets = bucketLogsByDay(logs)
+  const series: DailyTotals[] = []
+
+  for (let offset = days - 1; offset >= 0; offset--) {
+    const day = new Date(end)
+    day.setDate(end.getDate() - offset)
+    const key = toLocalDateKey(day)
+    const dayLogs = buckets.get(key) ?? []
+    series.push({
+      date: key,
+      count: dayLogs.length,
+      ...sumNutritionLogs(dayLogs),
+    })
+  }
+
+  return series
+}
+
+/**
+ * Convenience helper that returns just the totals for "today" in local time.
+ */
+export function getTodayTotals(
+  logs: NutritionLog[],
+  now: Date = new Date()
+): NutritionTotals {
+  const start = startOfLocalDay(now)
+  const end = endOfLocalDay(now)
+  return sumNutritionLogs(filterLogsInRange(logs, start, end))
+}

--- a/src/lib/calorie-aggregations.ts
+++ b/src/lib/calorie-aggregations.ts
@@ -95,7 +95,10 @@ export function filterLogsInRange(
 function bucketLogsByDay(logs: NutritionLog[]): Map<string, NutritionLog[]> {
   const buckets = new Map<string, NutritionLog[]>()
   for (const log of logs) {
-    const key = toLocalDateKey(new Date(log.logged_at))
+    const date = new Date(log.logged_at)
+    // Skip unparseable timestamps so they do not produce `NaN-NaN-NaN` keys.
+    if (Number.isNaN(date.getTime())) continue
+    const key = toLocalDateKey(date)
     const bucket = buckets.get(key)
     if (bucket) bucket.push(log)
     else buckets.set(key, [log])


### PR DESCRIPTION
## Summary

Adds a server-rendered calorie dashboard at `/calorie-tracker/dashboard` with:

- **Daily / weekly summary cards** for calories, protein, carbs, and fat with a `Today` / `This Week` / `Last 7 Days` range toggle.
- **7-day calorie trend bar chart** powered by Recharts.
- **Meal history grouped by local day** with photo thumbnails. Signed URLs for thumbnails are batched into a single `createSignedUrls` call to avoid an N+1 storage pattern.
- **View / edit / delete** actions on each meal with modal dialogs. Edits and deletes go through new `PATCH` / `DELETE` handlers on `/api/nutrition-logs/[id]`. RLS still enforces ownership; explicit `eq('user_id', user.id)` filters are used as defense-in-depth.
- Loading / empty states and a link from `/calorie-tracker` into the new dashboard.
- `src/lib/calorie-aggregations.ts` (with **18 Jest unit tests**) holds all date bucketing / total-summing logic.
- A minimal `jest.config.ts` was added so `ts-jest` can resolve project paths and run the new tests.

## New files

- `src/lib/calorie-aggregations.ts` + `.test.ts`
- `src/app/api/nutrition-logs/[id]/route.ts`
- `src/app/calorie-tracker/dashboard/page.tsx`
- `src/components/calorie-dashboard/{CalorieDashboard,SummaryStats,CaloriesChart,MealHistory,MealDetailsDialog,MealEditDialog,ConfirmDeleteDialog,Modal,format-helpers}.{ts,tsx}`
- `jest.config.ts`

## Test plan

- [x] `npm run lint` — only pre-existing warnings remain
- [x] `npm run build` — passes; new route shows up at `/calorie-tracker/dashboard`
- [x] `npx jest src/lib/calorie-aggregations.test.ts` — 18 / 18 passing
- [ ] Manual: log a meal, open `/calorie-tracker/dashboard`, toggle ranges, edit / delete a meal, confirm photo thumbnails render
- [ ] Manual: confirm empty state when a fresh user has no logs

## Notes

- No DB migrations were required; existing `nutrition_logs` columns (incl. `image_path`) covered every need.
- CodeRabbit feedback will be addressed in a follow-up commit.

https://claude.ai/code/session_01KBqiSPC5RoHPNhG2RXHa9x

---
_Generated by [Claude Code](https://claude.ai/code/session_01KBqiSPC5RoHPNhG2RXHa9x)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calorie tracker dashboard displays nutrition summary and 7-day trend visualization.
  * View, edit, and delete logged meals with detailed nutrition breakdowns.
  * Filter meals by custom date ranges.
  * Add photos and notes to meal entries.

* **Tests**
  * Added comprehensive test suite for nutrition data aggregation.

* **Chores**
  * Configured Jest testing framework.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->